### PR TITLE
Fix typo in certificates generation

### DIFF
--- a/root/etc/cont-init.d/30-keygen
+++ b/root/etc/cont-init.d/30-keygen
@@ -4,7 +4,7 @@
 [[ ! -f /config/data/keystore ]] && \
 	keytool -genkey -keyalg RSA -alias unifi -keystore /config/data/keystore \
 	-storepass aircontrolenterprise -keypass aircontrolenterprise -validity 1825 \
-	-keysize 4096 -dname "cn=unfi"
+	-keysize 4096 -dname "cn=unifi"
 
 # permissions
 chown abc:abc \


### PR DESCRIPTION
dname: "unfi" -> "unifi"

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

